### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: typos-cli,taplo-cli,hawkeye@7.0.0
+          tool: typos-cli,taplo-cli,hawkeye
       - run: cargo x lint
 
   msrv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: typos-cli,taplo-cli,hawkeye
+          tool: typos-cli,taplo-cli,hawkeye@7.0.0
       - run: cargo x lint
 
   msrv:

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-headerPath = "Apache-2.0.txt"
+[header]
+builtin = "Apache-2.0"
 
+[files]
 includes = ['**/*.rs', '**/*.yml', '**/*.yaml', '**/*.toml']
 
-[properties]
-copyrightOwner = "FastLabs Developers"
-inceptionYear = 2026
+[props]
+copyright_owner = "FastLabs Developers"
+inception_year = 2026

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -207,7 +207,7 @@ fn make_doc_cmd() -> StdCommand {
 }
 
 fn make_hawkeye_cmd(fix: bool) -> StdCommand {
-    ensure_installed("hawkeye", "hawkeye@7.0.0");
+    ensure_installed("hawkeye", "hawkeye");
     let mut cmd = find_command("hawkeye");
     if fix {
         cmd.args(["format"]);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -207,10 +207,10 @@ fn make_doc_cmd() -> StdCommand {
 }
 
 fn make_hawkeye_cmd(fix: bool) -> StdCommand {
-    ensure_installed("hawkeye", "hawkeye");
+    ensure_installed("hawkeye", "hawkeye@7.0.0");
     let mut cmd = find_command("hawkeye");
     if fix {
-        cmd.args(["format", "--fail-if-updated=false"]);
+        cmd.args(["format"]);
     } else {
         cmd.args(["check"]);
     }


### PR DESCRIPTION
## Summary

- migrate licenserc.toml to the HawkEye v7 schema and bundled Apache 2.0 header
- install the latest HawkEye in CI and xtask
- remove the v6-only format failure option